### PR TITLE
Improve chat UI and error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,7 +89,8 @@ def send_message():
     try:
         ai_reply = provider_completion(system_prompt, messages, chat_state['provider'], chat_state['api_key'], chat_state['model'])
     except Exception as e:
-        ai_reply = f"Error from provider: {e}"
+        print('Provider error:', e)
+        ai_reply = 'Sorry, there was an error contacting the AI provider.'
 
     chat_state['messages'].append({'role': 'assistant', 'content': ai_reply})
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,7 @@
 <head>
   <title>Story Chat Bot</title>
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <style>
     body { font-family: Arial, sans-serif; margin: 20px auto; max-width: 800px; }
     textarea { width: 100%; height: 80px; }
@@ -57,9 +58,9 @@ $(function(){
     var msg=$('#chat-input').val();
     if(!msg.trim()) return;
     $('#chat-input').val('');
-    $('#chat-box').append('<div class="msg"><b>You:</b> '+msg+'</div>');
+    $('#chat-box').append('<div class="msg"><b>You:</b> '+marked.parse(msg)+'</div>');
     $.post('/send_message', {message: msg}, function(data){
-      $('#chat-box').append('<div class="msg ai"><b>AI:</b> '+data.reply+'</div>');
+      $('#chat-box').append('<div class="msg ai"><b>AI:</b> '+marked.parse(data.reply)+'</div>');
       $('#chat-box').scrollTop($('#chat-box')[0].scrollHeight);
     });
   }


### PR DESCRIPTION
## Summary
- add Markdown rendering on the client using marked.js
- show a friendlier message when provider errors occur

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68488bfb4f588333ba788bde27d27c0c